### PR TITLE
Misc Updates

### DIFF
--- a/Cloudformations scripts/autoscale-tg-ngfw.json
+++ b/Cloudformations scripts/autoscale-tg-ngfw.json
@@ -117,7 +117,7 @@
             "Properties": {
                 "Description": "Copies objects from a source S3 bucket to a destination",
                 "Handler": "index.handler",
-                "Runtime": "python2.7",
+                "Runtime": "python3.8",
                 "Role": {
                     "Fn::GetAtt": [
                         "CopyZipsRole",
@@ -258,7 +258,7 @@
                     },
                     {
                         "Key": "Name",
-                        "Value": "vpc-ngfw-igw"
+                        "Value": "test-tgw-vpc-ngfw-igw"
                     }
                 ]
             },
@@ -285,7 +285,7 @@
                     },
                     {
                         "Key": "Name",
-                        "Value": "vpc-ngfw-rtb"
+                        "Value": "test-tgw-vpc-ngfw-rtb"
                     }
                 ]
             },
@@ -459,7 +459,7 @@
                 "Tags": [
                     {
                         "Key": "Name",
-                        "Value": "tgw-att-ngfw"
+                        "Value": "test-tgw-att-ngfw"
                     },
                     {
                         "Key": "scenario",
@@ -711,134 +711,7 @@
                 "NGFWAutoscalingGroup"
             ]
         },
-        "messageRole": {
-            "Type": "AWS::IAM::Role",
-            "Properties": {
-                "ManagedPolicyArns": [
-                    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-                    "arn:aws:iam::aws:policy/AdministratorAccess"
-                ],
-                "AssumeRolePolicyDocument": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Principal": {
-                                "Service": "lambda.amazonaws.com"
-                            },
-                            "Action": "sts:AssumeRole"
-                        }
-                    ]
-                },
-                "Policies": [
-                    {
-                        "PolicyName": "LifecycleFunctionLogsPolicy",
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "logs:CreateLogGroup",
-                                        "logs:CreateLogStream",
-                                        "logs:PutLogEvents"
-                                    ],
-                                    "Resource": "*"
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "PolicyName": "LifecycleFunctionSSMSendCommandDocumentPolicy",
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "ssm:SendCommand"
-                                    ],
-                                    "Resource": {
-                                        "Fn::Sub": "arn:aws:ssm:${AWS::Region}::document/AWS-RunShellScript"
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "PolicyName": "LifecycleFunctionSSMSendCommandInstancePolicy",
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "ssm:SendCommand"
-                                    ],
-                                    "Resource": "arn:aws:ec2:*:*:instance/*",
-                                    "Condition": {
-                                        "StringEquals": {
-                                            "ssm:ResourceTag/aws:autoscaling:groupName": [
-                                                {
-                                                    "Ref": "NGFWAutoscalingGroup"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "PolicyName": "LifecycleFunctionSSMGetCommandInvocationPolicy",
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "ssm:GetCommandInvocation"
-                                    ],
-                                    "Resource": "*"
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "PolicyName": "LogAutoScalingEventPolicy",
-                        "PolicyDocument": {
-                            "Version": "2012-10-17",
-                            "Statement": [
-                                {
-                                    "Effect": "Allow",
-                                    "Action": [
-                                        "autoscaling:CompleteLifecycleAction"
-                                    ],
-                                    "Resource": {
-                                        "Fn::Sub": [
-                                            "arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${ASGroupName}",
-                                            {
-                                                "ASGroupName": {
-                                                    "Ref": "NGFWAutoscalingGroup"
-                                                }
-                                            }
-                                        ]
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            },
-            "Metadata": {
-                "AWS::CloudFormation::Designer": {
-                    "id": "2a58ffb2-6eae-47ea-a57f-8ddc98fa65b0"
-                }
-            },
-            "DependsOn": [
-                "NGFWAutoscalingGroup"
-            ]
-        },
+
         "NGFWLaunchTemplate": {
             "Type": "AWS::EC2::LaunchTemplate",
             "Properties": {

--- a/PackageHelper.py
+++ b/PackageHelper.py
@@ -1,3 +1,4 @@
+import sys
 import json
 import urllib.parse as urlparse
 import smcConnector.Config as Config
@@ -13,10 +14,22 @@ def remove_subnet_elements(series, item, az):
             del data['Resources']['EC2TGA52Z3K']['Properties']['SubnetIds'][position]
         position += 1
 
+log_server_pool = Config.get_logserver_pool()
+location = Config.get_location()
+
+if not log_server_pool:
+    log_server_pool = False
+
+if not location:
+    location = "cloud"
 
 json_string = {
-    "smc-contact": {"address": address.hostname, "port": address.port, "apikey": Config.get_api_key(), "tls": True,
-                    "check_certificate": False}, "location": "cloud", "auto-delete": False, "type": "single-firewall"}
+    "smc-contact": {"address": address.hostname, "port": address.port,
+                    "apikey": Config.get_api_key(), "tls": True,
+                    "check_certificate": False},
+    "location": location, "auto-delete": False, "type": "single-firewall",
+    "log-server-pool": log_server_pool
+}
 
 with open("Cloudformations scripts/autoscale-tg-ngfw.json", "r") as jsonFile:
     data = json.load(jsonFile)
@@ -26,9 +39,29 @@ data['Parameters']['BucketName']['Default'] = Config.get_lambda_bucket_name()
 data['Resources']['ngfwSubnet1a']['Properties']['AvailabilityZone'] = Config.get_availability_zone_1()
 data['Resources']['NGFWAutoscalingGroup']['Properties']['AvailabilityZones'][0] = Config.get_availability_zone_1()
 
+vpc_net = Config.get_vpc_network()
+if vpc_net:
+    data['Resources']['vpc0b40973e5aa01818f']['Properties']['CidrBlock'] = vpc_net
+
+
+subnet1 = Config.get_availability_zone_1_subnet()
+if vpc_net and not subnet1:
+    print("Invalid config.json. VPC network {} given. But no availibity " \
+          "zone 1 subnet".format(vpc_net))
+    sys.exit(1)
+if subnet1:
+    data['Resources']['ngfwSubnet1a']['Properties']['CidrBlock'] = subnet1
+
 if Config.get_availability_zone_2():
     data['Resources']['ngfwSubnet1b']['Properties']['AvailabilityZone'] = Config.get_availability_zone_2()
     data['Resources']['NGFWAutoscalingGroup']['Properties']['AvailabilityZones'][1] = Config.get_availability_zone_2()
+    subnet = Config.get_availability_zone_2_subnet()
+    if vpc_net and not subnet:
+        print("Invalid config.json. VPC network {} given. But no availibity " \
+              "zone 2 subnet".format(vpc_net))
+        sys.exit(1)
+    if subnet:
+        data['Resources']['ngfwSubnet1b']['Properties']['CidrBlock'] = subnet
 
 else:
     del data['Resources']['ngfwSubnet1b']
@@ -67,6 +100,13 @@ else:
 if Config.get_availability_zone_3():
     data['Resources']['ngfwSubnet1c']['Properties']['AvailabilityZone'] = Config.get_availability_zone_3()
     data['Resources']['NGFWAutoscalingGroup']['Properties']['AvailabilityZones'][2] = Config.get_availability_zone_3()
+    subnet = Config.get_availability_zone_3_subnet();
+    if vpc_net and not subnet:
+        print("Invalid config.json. VPC network {} given. But no availibity " \
+              "zone 3 subnet".format(vpc_net))
+        sys.exit(1)
+    if subnet:
+        data['Resources']['ngfwSubnet1c']['Properties']['CidrBlock'] = subnet
 else:
     del data['Resources']['ngfwSubnet1c']
     del data['Resources']['RouteTableAssociationc']
@@ -104,5 +144,15 @@ else:
 data['Resources']['NGFWLaunchTemplate']['Properties']['LaunchTemplateData']['ImageId'] = Config.get_ngfw_ami()
 
 
-with open("autoscale-tg-ngfw.json", "w") as jsonFile:
+out_file_name = "autoscale-tg-ngfw.json"
+with open(out_file_name, "w") as jsonFile:
     json.dump(data, jsonFile)
+
+name_prefix = Config.get_name_prefix()
+
+import subprocess
+if name_prefix:
+    cmd = "sed -i.bak 's/test-tgw/{}/g' {}".format(name_prefix, out_file_name)
+    ret = subprocess.run(cmd, shell=True)
+    # print("{} -> {}".format(cmd, ret))
+

--- a/config.json
+++ b/config.json
@@ -1,12 +1,22 @@
 {
   "url":"https://YOUR_PUBLIC_IP:8082",
+  "api_version ":"6.10",
   "api_key":"SMC_API_KEY",
-  "api_version":"6.8",
   "region":"AWS_REGION",
   "availability_zone_1": "AWS_AZ_1",
   "availability_zone_2": "AWS_AZ_2",
   "availability_zone_3": "AWS_AZ_3",
   "ngfw_ami": "NGFW_AMI",
   "lambda_bucket_name": "AWS_BUCKET_NAME"
+  "lambda_bucket_name": "bd-tg-ngfw",
+  "vpc_network": "100.64.0.0/16",
+  "availability_zone_1_subnet": "100.64.0.0/24",
+  "availability_zone_2_subnet": "100.64.1.0/24",
+  "availability_zone_3_subnet": "100.64.2.0/24",
+  "cloud_formation_name_prefix": "test-tgw",
+  "___logserver_pool": [ "DELETE leading ___ and give comma separted list of log servers. If you have log server pool. For example LOGSERVER-01, LOGSERVER-02" ],
+  "location": "cloud",
+  "protected_network": "10.0.0.0/8",
+  "policy_name": "transit_gw_policy"
 }
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -10,7 +10,8 @@ import boto3
 from smcConnector.ipFomat import MyIPv4, string_to_ip
 from smcConnector.EngineCreation import engine_creation
 from smcConnector.TransitGatewayBridge import smc_configuration, remove_smc_engines
-
+import smcConnector.Config as Config
+from smcConnector.AwsConnector import get_tgw_route_table, get_vpn
 parent_dir = os.path.abspath(os.path.dirname(__file__))
 vendor_dir = os.path.join(parent_dir, 'Libs')
 pem_dir = os.path.join(parent_dir, 'smc.pem')
@@ -24,25 +25,71 @@ def get_aws_client(resource):
     return boto3.client(resource)
 
 
+def attach_vpn_to_transit_gw(engine_name, public_ip, tgw):
+    engine_list = engine_name.split(",")
+    tgw_route_table = get_tgw_route_table(tgw)
+    client = get_aws_client('ec2')
+    public_ip_list = public_ip.split(",")
+
+    for engine in engine_list:
+        i = 12
+        assoc_done = False
+        vpn_name, tunnel_1, tunnel_2, cgw_tgw_attachment, vpc_tgw_attachment = \
+            get_vpn(public_ip_list[engine_list.index(engine)])
+
+        while i > 0:
+            try:
+                if not assoc_done:
+                    response = client.associate_transit_gateway_route_table(
+                        TransitGatewayRouteTableId=tgw_route_table,
+                        TransitGatewayAttachmentId=cgw_tgw_attachment)
+                    print("tgw VPN route assocation attachment OK! RESP {}".format(response))
+                    assoc_done = True
+                response = client.enable_transit_gateway_route_table_propagation(
+                    TransitGatewayRouteTableId=tgw_route_table,
+                    TransitGatewayAttachmentId=cgw_tgw_attachment)
+                print("tgw VPN route propagation OK! RESP {}".format(response))
+                break
+            except Exception as e:
+                print("tgw route attachment error {}".format(e))
+                time.sleep(10)
+
+            i = i - 1
+
+        ret = client.modify_transit_gateway_vpc_attachment(
+            TransitGatewayAttachmentId=vpc_tgw_attachment,
+            Options={
+                'ApplianceModeSupport': 'enable'
+            }
+        )
+        print("modifided tgw vpc attchemnt {} ret={}"
+              .format(vpc_tgw_attachment, ret))
+
 def configure_smc_engines(engine_name, private_ip, public_ip):
     engine_list = engine_name.split(",")
     private_ip_list = private_ip.split(",")
     public_ip_list = public_ip.split(",")
+
+    protected_network = Config.get_protected_network()
+    if not protected_network:
+        protected_network = PROTECTED_NETWORK
 
     for engine in engine_list:
         base = MyIPv4(private_ip_list[engine_list.index(engine)]) & MyIPv4(MASK)
         router_ip = base + 1
         private_network = string_to_ip(str(base) + '/24')
 
-        engine_creation(engine, private_ip_list[engine_list.index(engine)], public_ip_list[engine_list.index(engine)],
-                        PROTECTED_NETWORK, str(router_ip), str(private_network))
+        engine_creation(engine, private_ip_list[engine_list.index(engine)],
+                        public_ip_list[engine_list.index(engine)],
+                        protected_network, str(router_ip), str(private_network))
 
         public_base = MyIPv4(public_ip_list[engine_list.index(engine)]) & MyIPv4(MASK)
         public_network = string_to_ip(str(public_base) + '/24')
 
-        smc_configuration(engine, public_ip_list[engine_list.index(engine)], private_ip_list[engine_list.index(engine)],
+        smc_configuration(engine,
+                          public_ip_list[engine_list.index(engine)],
+                          private_ip_list[engine_list.index(engine)],
                           str(public_network))
-
 
 def scale_back_instances(event, context):
     client = get_aws_client('ec2')
@@ -53,6 +100,7 @@ def scale_back_instances(event, context):
         ]
     )
     if instance:
+        print("Instance down {}".format(instance))
         public_ip = instance['Reservations'][0]['Instances'][0]['PublicIpAddress']
         private_ip = instance['Reservations'][0]['Instances'][0]['PrivateIpAddress']
         instance_name = event['detail']['EC2InstanceId']
@@ -67,20 +115,24 @@ def scale_back_instances(event, context):
         client.release_address(
             AllocationId=eip_description['Addresses'][0]['AllocationId']
         )
+        public_ip = instance['Reservations'][0]['Instances'][0]['PublicIpAddress']
         gateway = client.describe_customer_gateways(Filters=[
             {
                 'Name': 'ip-address',
-                'Values': [instance['Reservations'][0]['Instances'][0]['PublicIpAddress']]
+                'Values': [ public_ip ]
             },
         ])['CustomerGateways'][0]['CustomerGatewayId']
+        print("GW {} for {}".format(gateway, public_ip))
         vpn_connections = client.describe_vpn_connections(Filters=[
             {
                 'Name': 'customer-gateway-id',
                 'Values': [
                     gateway,
                 ]
-            },
-        ])['VpnConnections'][0]['VpnConnectionId']
+            }
+        ])
+        print("VPN connections {}".format(vpn_connections))
+        vpn_connections = vpn_connections['VpnConnections'][0]['VpnConnectionId']
 
         response_vpn = client.delete_vpn_connection(
             VpnConnectionId=vpn_connections
@@ -90,6 +142,7 @@ def scale_back_instances(event, context):
         )
     # last step
     remove_smc_engines(instance_name, public_ip, private_ip)
+    print("Scaling down ok")
 
 
 def scale_up_instances(event, context):
@@ -114,14 +167,28 @@ def scale_up_instances(event, context):
     private_ip = instance['Reservations'][0]['Instances'][0]['PrivateIpAddress']
 
     tg_gateways = client.describe_transit_gateways()
-    for tg_gateway in tg_gateways['TransitGateways']:
-        if tg_gateway['Tags'][0]['Value'] == 'test-tgw':
-            transit_gateway_id = tg_gateway['TransitGatewayId']
-    gws = client.describe_customer_gateways()
+    tgw_name = Config.get_name_prefix()
+    if not tgw_name:
+        tgw_name = "test-tgw"
 
+    transit_gateway_id = False
+    for tg_gateway in tg_gateways['TransitGateways']:
+        print("Checking TGW {} for name {}".format(tg_gateway, tgw_name))
+        if tg_gateway['State'] == 'available' and \
+           tg_gateway['Tags'][0]['Value'] == tgw_name:
+            transit_gateway_id = tg_gateway['TransitGatewayId']
+            print("Found TGW {}".format(transit_gateway_id))
+
+    gws = client.describe_customer_gateways()
     create_gateway = True
+
+    if not transit_gateway_id:
+        print("Did not find TGW {}", tgw_name)
+        return
+
     for customer_gateway in gws['CustomerGateways']:
         if customer_gateway['IpAddress'] == public_ip:
+            print("Using customer GW {}".format(customer_gateway))
             create_gateway = False
 
     if create_gateway:
@@ -131,8 +198,13 @@ def scale_up_instances(event, context):
                                      TransitGatewayId=transit_gateway_id,
                                      Options={
                                          'StaticRoutesOnly': False})
-    time.sleep(150)
-    configure_smc_engines(event['detail']['EC2InstanceId'], private_ip, public_ip)
+    time.sleep(120) # Let the transit gatway and attachment go active
+    configure_smc_engines(event['detail']['EC2InstanceId'],
+                          private_ip, public_ip)
+    time.sleep(45) # Policy upload and VPN UP for transit gateway
+    attach_vpn_to_transit_gw(event['detail']['EC2InstanceId'],
+                          public_ip, transit_gateway_id);
+
 
 
 def lambda_handler(event, context):

--- a/package.sh
+++ b/package.sh
@@ -1,11 +1,14 @@
-rm ./autoscale-tg-ngfw.json
-rm ./myDeploymentPackage.zip
-pip3 install -r ./Packager/requirements.txt -t ./smcConnector/Libs
+set -e
+rm ./autoscale-tg-ngfw.json || true
+rm ./myDeploymentPackage.zip || true
+echo "Installing python3 requirements"
+pip3 -q install -r ./Packager/requirements.txt -t ./smcConnector/Libs
 chmod -R 755 ./smcConnector/.
-python3 PackageHelper.py
+
+python3 PackageHelper.py || (echo "Check that config.json has correct availability zone  configuration. AZ1 and AZ2 are mandatory"; exit 1)
 cp ./smc.pem ./smcConnector/
-zip -r ./myDeploymentPackage.zip ./smcConnector
-zip -ur ./myDeploymentPackage.zip ./lambda_function.py
-zip -ur ./myDeploymentPackage.zip ./config.json
+zip --quiet -r ./myDeploymentPackage.zip ./smcConnector
+zip --quiet -ur ./myDeploymentPackage.zip ./lambda_function.py
+zip --quiet -ur ./myDeploymentPackage.zip ./config.json
 rm -r ./smcConnector/Libs
 rm ./smcConnector/smc.pem

--- a/smcConnector/AwsConnector.py
+++ b/smcConnector/AwsConnector.py
@@ -32,16 +32,73 @@ def __describe_vpn_connections(customer_gateway_id):
 
     return response
 
+def __describe_tgw_attachment(customer_gateway_vpn_id):
+    response = boto3.client('ec2').describe_transit_gateway_attachments(
+        Filters=[
+            {
+                'Name': 'resource-id',
+                'Values': [
+                    customer_gateway_vpn_id,
+                ]
+            },
+        ])
+
+    return response
+
+def __describe_tgw_vpc_attachment():
+    response = boto3.client('ec2').describe_transit_gateway_attachments(
+        Filters=[
+            {
+                'Name': 'resource-type',
+                'Values': [
+                    'vpc',
+                ]
+            },
+        ])
+
+    return response
+
+def __describe_tgw_route_table(transit_gateway_id):
+    response = boto3.client('ec2').describe_transit_gateway_route_tables(
+        Filters=[
+            {
+                'Name': 'transit-gateway-id',
+                'Values': [
+                    transit_gateway_id,
+                ]
+            },
+        ])
+
+    return response
+
+
+def get_tgw_route_table(tgw_id):
+    resp = __describe_tgw_route_table(tgw_id)
+    print("TGW {} has route tables {}".format(tgw_id, resp))
+    return resp['TransitGatewayRouteTables'][0]['TransitGatewayRouteTableId']
 
 def get_vpn(public_ip):
-    tunnel_1 = {'outside_ip': '', 'inside_ip_cidr': '', 'gateway': '', 'pre_shared_key': ''}
-    tunnel_2 = {'outside_ip': '', 'inside_ip_cidr': '', 'gateway': '', 'pre_shared_key': ''}
+    tunnel_1 = {'outside_ip': '', 'inside_ip_cidr': '', 'gateway_inside_ip': '',
+                'pre_shared_key': '', 'cust_inside_ip': ''}
+    tunnel_2 = {'outside_ip': '', 'inside_ip_cidr': '', 'gateway': '',
+                'pre_shared_key': '', 'cust_inside_ip': ''}
 
     customer_gateway = __describe_customer_gateway(public_ip)
-    customer_gateway_configuration = __describe_vpn_connections(
-        customer_gateway['CustomerGateways'][0]['CustomerGatewayId'])
-    vpn_name = customer_gateway_configuration['VpnConnections'][0]['VpnConnectionId']
+    cgw_id = customer_gateway['CustomerGateways'][0]['CustomerGatewayId']
 
+    customer_gateway_configuration = __describe_vpn_connections(cgw_id)
+    print("CGW  {} CFG {}".format(customer_gateway,
+                                  customer_gateway_configuration))
+
+    vpn_name = customer_gateway_configuration['VpnConnections'][0]['VpnConnectionId']
+    tgw_attachment = __describe_tgw_attachment(vpn_name)
+    print("CGW_id {} tgw_attachment {}".format(cgw_id, tgw_attachment))
+    tgw_attachment_id = tgw_attachment['TransitGatewayAttachments'][0]['TransitGatewayAttachmentId']
+    print("CGW_id {} tgw_attachment_id {} data {}"
+          .format(cgw_id, tgw_attachment_id, tgw_attachment))
+
+    tgw_attachment = __describe_tgw_vpc_attachment()
+    tgw_vpc_attachment_id = tgw_attachment['TransitGatewayAttachments'][0]['TransitGatewayAttachmentId']
     doc = parse(customer_gateway_configuration['VpnConnections'][0]['CustomerGatewayConfiguration'])
 
     cidr = doc['vpn_connection']['ipsec_tunnel'][0]['customer_gateway']['tunnel_inside_address']['network_cidr']
@@ -51,7 +108,8 @@ def get_vpn(public_ip):
     tunnel_1['outside_ip'] = doc['vpn_connection']['ipsec_tunnel'][0]['vpn_gateway']['tunnel_outside_address'][
         'ip_address']
     tunnel_1['inside_ip_cidr'] = f'{str(tunnel & MyIPv4(mask))}/{cidr}'
-    tunnel_1['gateway'] = str(tunnel & MyIPv4(mask))
+    tunnel_1['cust_inside_ip'] = str(tunnel)
+    tunnel_1['gateway_inside_ip'] = doc['vpn_connection']['ipsec_tunnel'][0]['vpn_gateway']['tunnel_inside_address']['ip_address']
     tunnel_1['pre_shared_key'] = doc['vpn_connection']['ipsec_tunnel'][0]['ike']['pre_shared_key']
 
     cidr = doc['vpn_connection']['ipsec_tunnel'][1]['customer_gateway']['tunnel_inside_address']['network_cidr']
@@ -61,7 +119,8 @@ def get_vpn(public_ip):
     tunnel_2['outside_ip'] = doc['vpn_connection']['ipsec_tunnel'][1]['vpn_gateway']['tunnel_outside_address'][
         'ip_address']
     tunnel_2['inside_ip_cidr'] = f'{str(tunnel & MyIPv4(mask))}/{cidr}'
-    tunnel_2['gateway'] = str(tunnel & MyIPv4(mask))
+    tunnel_2['cust_inside_ip'] = str(tunnel)
+    tunnel_2['gateway_inside_ip'] = doc['vpn_connection']['ipsec_tunnel'][1]['vpn_gateway']['tunnel_inside_address']['ip_address']
     tunnel_2['pre_shared_key'] = doc['vpn_connection']['ipsec_tunnel'][1]['ike']['pre_shared_key']
 
-    return vpn_name, tunnel_1, tunnel_2
+    return vpn_name, tunnel_1, tunnel_2, tgw_attachment_id, tgw_vpc_attachment_id

--- a/smcConnector/Config.py
+++ b/smcConnector/Config.py
@@ -27,18 +27,78 @@ def get_api_version(config_file=__config_file):
 def get_region(config_file=__config_file):
     return __get_configurations(config_file)['region']
 
+def get_vpc_network(config_file=__config_file):
+    try:
+        return __get_configurations(config_file)['vpc_network']
+    except:
+        False
+
+def get_name_prefix(config_file=__config_file):
+    try:
+        return __get_configurations(config_file)['cloud_formation_name_prefix']
+    except:
+        False
+
+def get_policy_name(config_file=__config_file):
+    try:
+        return __get_configurations(config_file)['policy_name']
+    except:
+        False
+
+def get_logserver_pool(config_file=__config_file):
+    try:
+        return __get_configurations(config_file)['logserver_pool']
+    except:
+        False
+
+def get_location(config_file=__config_file):
+    try:
+        return __get_configurations(config_file)['location']
+    except:
+        False
+
+def get_protected_network(config_file=__config_file):
+    try:
+        return __get_configurations(config_file)['protected_network']
+    except:
+        False
 
 def get_availability_zone_1(config_file=__config_file):
     return __get_configurations(config_file)['availability_zone_1']
+
+def get_availability_zone_1_subnet(config_file=__config_file):
+    try:
+        return __get_configurations(config_file)['availability_zone_1_subnet']
+    except:
+        False
+
+def get_availability_zone_1_subnet(config_file=__config_file):
+    try:
+        return __get_configurations(config_file)['availability_zone_1_subnet']
+    except:
+        False
 
 
 def get_availability_zone_2(config_file=__config_file):
     return __get_configurations(config_file)['availability_zone_2']
 
+def get_availability_zone_2_subnet(config_file=__config_file):
+    try:
+        return __get_configurations(config_file)['availability_zone_2_subnet']
+    except:
+        False
 
 def get_availability_zone_3(config_file=__config_file):
-    return __get_configurations(config_file)['availability_zone_3']
+    try:
+        return __get_configurations(config_file)['availability_zone_3']
+    except:
+        False
 
+def get_availability_zone_3_subnet(config_file=__config_file):
+    try:
+        return __get_configurations(config_file)['availability_zone_3_subnet']
+    except:
+        False
 
 def get_ngfw_ami(config_file=__config_file):
     return __get_configurations(config_file)['ngfw_ami']

--- a/smcConnector/EngineCreation.py
+++ b/smcConnector/EngineCreation.py
@@ -3,26 +3,31 @@ import os
 import sys
 import time
 
-from smcConnector.Config import get_url, get_api_version, get_api_key
-
 parent_dir = os.path.abspath(os.path.dirname(__file__))
 vendor_dir = os.path.join(parent_dir, 'Libs')
-pem_dir = os.path.join(parent_dir, 'smc.pem')
+
 sys.path.append(vendor_dir)
 
+from smcConnector.common import session_login
 import smc
 from smc import session
 from smc.core.engine import Engine
 from smc.elements.network import Router, Network
 from smc.vpn.elements import VPNProfile
 
-PROFILE_NAME = "aws_profile"
 
+PROFILE_NAME = "aws_profile"
+#import logging
+#logging.getLogger()
+#logging.basicConfig(level=logging.DEBUG,
+#                    format='%(asctime)s %(levelname)s: %(message)s')
 
 def engine_creation(engine_name, private_ip, public_ip, protected_network, router_ip, private_network):
-    session.login(url=get_url(), api_key=get_api_key(), api_version=get_api_version(), verify=pem_dir)
+    session_login()
 
     profile = VPNProfile.get_or_create(name=PROFILE_NAME)
+ #   print("Got profile {}".format(profile))
+ #   sys.exit(0)
     profile.update(capabilities=
     {
         'ike_v1': True,
@@ -97,3 +102,5 @@ def engine_creation(engine_name, private_ip, public_ip, protected_network, route
     ca.add_contact_address(public_ip, location='Default')
 
     session.logout()
+
+#engine_creation("1", "2", "3", "4", 5, 6)

--- a/smcConnector/common.py
+++ b/smcConnector/common.py
@@ -1,0 +1,33 @@
+""" Provide common util functions """
+
+import os
+import sys
+import urllib3
+from smcConnector.Config import get_url, get_api_version, get_api_key
+
+PARENT_DIR = os.path.abspath(os.path.dirname(__file__))
+VENDOR_DIR = os.path.join(PARENT_DIR, 'Libs')
+PEM_FILE = os.path.join(PARENT_DIR, 'smc.pem')
+
+sys.path.append(VENDOR_DIR)
+
+import smc
+from smc import session
+
+def session_login():
+    """
+    Login to SMC with API. If PEM_FILE is exists and non zero 0, then
+    certifiicate verification is done
+    """
+    do_verify = False
+    try:
+        file_size = os.path.getsize(PEM_FILE)
+        if file_size != 0:
+            do_verify = PEM_FILE
+    except OSError:
+        pass
+
+    if not do_verify:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    session.login(url=get_url(), api_key=get_api_key(),
+                  api_version=get_api_version(), verify=do_verify)


### PR DESCRIPTION
- Use python3.8 instead in 2.7 in cloud formation template
- Removed unused IAM role form cloud formation template
- Added more configuration options. See config.json.
- Empty smc.pem is now allowed means that lambda functions do not
  check validity of SMC TLS certificate
- Correctly bind VPN TGW attachment to TGW route
- Enable BGP ECMP by default
- Use correct IP addresses when configuring NGFW VPN tunnels
- Enable Appliance mode for transit gateway VPC attachment
- Handle multiple instance creation at same time. Try SMC policy
  actions multiple times, before bailing out
- Make some code more robust for repeating lambda calls